### PR TITLE
Remove trailing full stops from built-in form error messages

### DIFF
--- a/mtp_user_admin/__init__.py
+++ b/mtp_user_admin/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 6)
+VERSION = (0, 7)
 __version__ = '.'.join(map(str, VERSION))

--- a/mtp_user_admin/forms.py
+++ b/mtp_user_admin/forms.py
@@ -3,7 +3,7 @@ import logging
 
 from django import forms
 from django.core.validators import validate_email
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from moj_auth import api_client
 from slumber.exceptions import HttpClientError
 

--- a/mtp_user_admin/forms.py
+++ b/mtp_user_admin/forms.py
@@ -2,16 +2,22 @@ import json
 import logging
 
 from django import forms
+from django.core.validators import validate_email
 from django.utils.translation import ugettext_lazy as _
 from moj_auth import api_client
 from slumber.exceptions import HttpClientError
 
 logger = logging.getLogger('mtp')
 
+forms.CharField.default_error_messages = {
+    'required': _('This field is required'),
+}
+validate_email.message = _('Enter a valid email address')
+
 
 class UserUpdateForm(forms.Form):
     error_messages = {
-        'generic': _('The service is currently unavailable.')
+        'generic': _('The service is currently unavailable')
     }
 
     username = forms.CharField(label=_('Username'), disabled=True)

--- a/mtp_user_admin/tests/test_views.py
+++ b/mtp_user_admin/tests/test_views.py
@@ -2,19 +2,35 @@ from unittest import mock
 
 from django.core.urlresolvers import reverse
 from django.test import SimpleTestCase
-from slumber.exceptions import HttpNotFoundError
+from slumber.exceptions import HttpClientError, HttpNotFoundError
 
 
 @mock.patch('mtp_user_admin.views.api_client')
 class DeleteUserTestCase(SimpleTestCase):
 
-    def test_user_not_found_raises_404(self, mock_api_client):
+    def test_user_not_found(self, mock_api_client):
         conn = mock_api_client.get_connection()
-        conn.users().delete.side_effect = HttpNotFoundError()
+        conn.users.get.return_value = {}
+        conn.users().delete.side_effect = HttpNotFoundError(content=b'{"detail": "Not found"}')
 
         self.client.login(username='test-user')
-        response = self.client.post(reverse('delete-user', args={'username': 'test123'}))
-        self.assertEqual(response.status_code, 404)
+        response = self.client.post(reverse('delete-user', args={'username': 'test123'}),
+                                    follow=True)
+        messages = response.context['messages']
+        messages = [str(m) for m in messages]
+        self.assertIn('Not found', messages)
+
+    def test_cannot_delete_self(self, mock_api_client):
+        conn = mock_api_client.get_connection()
+        conn.users.get.return_value = {}
+        conn.users().delete.side_effect = HttpClientError(content=b'{"__all__": ["You cannot delete yourself"]}')
+
+        self.client.login(username='test-user')
+        response = self.client.post(reverse('delete-user', args={'username': 'test-user'}),
+                                    follow=True)
+        messages = response.context['messages']
+        messages = [str(m) for m in messages]
+        self.assertIn('You cannot delete yourself', messages)
 
 
 @mock.patch('mtp_user_admin.forms.api_client')

--- a/run_tests.py
+++ b/run_tests.py
@@ -16,17 +16,19 @@ DEFAULT_SETTINGS = dict(
         'django.contrib.contenttypes',
         'django.contrib.auth',
         'django.contrib.sessions',
+        'django.contrib.messages',
     ),
     OAUTHLIB_INSECURE_TRANSPORT=True,
     API_URL='http://localhost:8000',
     AUTHENTICATION_BACKENDS=['mtp_user_admin.tests.backends.TestBackend'],
     SESSION_ENGINE='django.contrib.sessions.backends.signed_cookies',
+    MESSAGE_STORAGE='django.contrib.messages.storage.session.SessionStorage',
     TEMPLATES=[{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [],
         'APP_DIRS': False,
         'OPTIONS': {
-            'context_processors': [],
+            'context_processors': ['django.contrib.messages.context_processors.messages'],
             'loaders': ['mtp_user_admin.tests.DummyTemplateLoader']
         },
     }],
@@ -35,6 +37,7 @@ DEFAULT_SETTINGS = dict(
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
     )
 )
 


### PR DESCRIPTION
and fix tests